### PR TITLE
Introduced new "large" overlay size

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -70,6 +70,7 @@
 @editorSizes:
     small 500px,
     medium 800px;
+    large 1600px;
 
 .create-editor-sizes(@iterator:1) when(@iterator <= length(@editorSizes)) {
     .umb-editor {
@@ -91,6 +92,11 @@
 }
 
 .create-editor-sizes();
+
+.umb-editor--large {
+    max-width: 1600px;
+    width: calc(100% - 50px);
+}
 
 .umb-editor__overlay {
     .absolute();

--- a/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
+++ b/src/Umbraco.Web.UI.Client/src/less/components/editor/umb-editor.less
@@ -69,7 +69,7 @@
 // and also use a loop to build editor sizes - easily extended with new sizes by adding to the map
 @editorSizes:
     small 500px,
-    medium 800px;
+    medium 800px,
     large 1600px;
 
 .create-editor-sizes(@iterator:1) when(@iterator <= length(@editorSizes)) {

--- a/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editors.html
+++ b/src/Umbraco.Web.UI.Client/src/views/components/editor/umb-editors.html
@@ -6,6 +6,7 @@
                          ng-attr-inert="{{$last ? undefined : true}}"
                          ng-class="{'umb-editor--small': model.size === 'small',
                 'umb-editor--medium': model.size === 'medium',
+                'umb-editor--large': model.size === 'large',
                 'umb-editor--animating': model.animating,
                 'umb-editor--notInFront': model.inFront !== true,
                 'umb-editor--infiniteMode': model.infiniteMode,


### PR DESCRIPTION
When opening overlays in Umbraco, we currently have `small` and `medium`, or the normal full width size if nothing else is specified.

I often feel I need a size bigger than `medium`, but also a size that doesn't take up the full width of the browser window, so this PR introduces a `large` size that is double the size of `medium` (800px vs 1600px).

But as the browser windows may be smaller than the new size (1600px), I've also added some CSS so the overlay won't take up more space than is available. To make this work, I've added the size to `@editorSizes` so it's gets the default CSS, but also a separate selector/style block to ensure it looks good in smaller window sizes.

This is relevant for Umbraco 9 - as well as Umbraco 8 if backoffice changes are still merged back to V8.

Here are some examples:

**Width: 950px**
![image](https://user-images.githubusercontent.com/3634580/152778430-c6a654ae-f552-44f8-b0fd-551f25814733.png)

**Width: 1718px** (half my screen width, give or take)
![image](https://user-images.githubusercontent.com/3634580/152778646-1b636e66-0d3c-4f00-9552-b1b399932e76.png)

**Width: 3440px** (full screen width)
![image](https://user-images.githubusercontent.com/3634580/152778797-9618d377-ee45-497c-b9e1-2caf265fa3ed.png)

The general experience for Umbraco on ultra wide monitors is still not super great, as some components are left aligned, while others are right aligned (overlays, submit buttons) etc. But at least I feel this is a step in the right direction.
