### PR TITLE
Added  shortcut="esc" to RTE HTML editor close button

### DIFF
--- a/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/codeeditor.html
+++ b/src/Umbraco.Web.UI.Client/src/views/propertyeditors/rte/codeeditor.html
@@ -25,6 +25,7 @@
                     type="button"
                     button-style="link"
                     label-key="general_close"
+                    shortcut="esc"
                     action="vm.close()">
                 </umb-button>
                 <umb-button


### PR DESCRIPTION
### Prerequisites

- [x] I have added steps to test this contribution in the description below

### Description

I've been meaning to fix this for a while, so I've created this PR after seeing that the issue still exists in the new 10.3.

For most of the overlays in the backoffice, the overlay can be closed by pressing the ESC key, as it's typically the shortcut for the overlay's close button.

However when editing the raw HTML of an RTE property editor, the close button doesn't have a shortcut. This PR therefore adds the shortcut so the overlay can be closed by pressing the ESC key.

![image](https://user-images.githubusercontent.com/3634580/196993967-a661e887-4db5-45dd-9817-f712a87bea30.png)

Reproducing the issue would be something like creating new content type with a property holding an RTE, creating a new content item of said content type, and then clicking the *View Source Code* in the RTE.

<!-- Thanks for contributing to Umbraco CMS! -->
